### PR TITLE
ElasticSearch - Send custom file to index, search custom query

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,18 +21,21 @@
   "homepage": "https://github.com/researchshare-official/backend#readme",
   "dependencies": {
     "@elastic/elasticsearch": "^7.15.0",
+    "@types/multer": "^1.4.7",
     "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
     "dotenv": "^10.0.0",
     "express": "^4.17.1",
-    "express-session": "^1.17.2"
+    "express-fileupload": "^1.2.1",
+    "express-session": "^1.17.2",
+    "multer": "^1.4.4"
   },
   "devDependencies": {
     "@types/express": "^4.17.13",
-    "prisma": "^3.6.0",
     "@typescript-eslint/eslint-plugin": "^5.6.0",
     "@typescript-eslint/parser": "^5.6.0",
     "eslint": "^8.4.1",
+    "prisma": "^3.6.0",
     "tsc-watch": "^4.5.0",
     "typescript": "^4.5.3"
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,10 +5,15 @@ import session from 'express-session'
 import dotenv from 'dotenv'
 // require('./search_engine')
 import {searchData, indexDoc, createIndex, putPipeline} from "./search_engine";
+import e from "express";
+import multer from "multer";
+import * as os from "os";
 
 dotenv.config({ path: 'backend.env' });
 dotenv.config({ path: 'db.env' });
 
+const fileUpload = require('express-fileupload');
+const upload = multer({ dest: os.tmpdir() });
 const app = express()
 const port = process.env.PORT || 3000
 
@@ -20,6 +25,12 @@ app.use(session({
     saveUninitialized: true
 }))
 app.use(cookieParser(process.env.SESSION_SECRET))
+app.use(fileUpload({
+    createParentPath: true,
+    limits: {
+        fileSize: 10 * 1024 * 1024 * 1024 //2MB max file(s) size
+    },
+}));
 
 app.get('/', (req, res) => {
     res.send('Hello World!')
@@ -27,12 +38,42 @@ app.get('/', (req, res) => {
 
 //Search on all index files
 app.get('/search', async (req, res) => {
-    const a = await searchData('true', 'researchshare');
+    await searchData(req.query.text, 'researchshare').then(value => {
+        res.send(value);
+    }).catch(e => {
+        res.send({result: "error"});
+    });
 })
 
 //Add a file to index
-app.get('/index', async (req, res) => {
-    const a = await indexDoc('tsconfig.json', 'researchshare');
+app.post('/index_file', upload.single('file'), async (req, res) => {
+    try {
+        if(!req.files) {
+            res.send({
+                status: false,
+                message: 'No file uploaded'
+            });
+        } else {
+            console.log("requ")
+            //Use the name of the input field (i.e. "avatar") to retrieve the uploaded file
+            let toindex = req.files["file"];
+
+            //Use the mv() method to place the file in upload directory (i.e. "uploads")
+            toindex.mv('/tmp/' + toindex.name);
+
+            //send response
+            await indexDoc(os.tmpdir() + '/' + toindex.name, 'researchshare').then(value => {
+                console.log(value);
+                res.send(value);
+            }).catch(e => {
+                console.log("fail")
+                console.log(e);
+                res.send({result: "error"});
+            })
+        }
+    } catch (err) {
+        res.status(500).send(err);
+    }
 })
 
 //This command first to initialise
@@ -44,5 +85,5 @@ app.get('/initialise', async (req, res) => {
 })
 
 app.listen(port, () => {
-    console.log(`server is running on freaking port ${port}`)
+    console.log(`server is running on this port ${port}`)
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,14 +55,12 @@ app.post('/index_file', upload.single('file'), async (req, res) => {
             });
         } else {
             console.log("requ")
-            //Use the name of the input field (i.e. "avatar") to retrieve the uploaded file
             let toindex = req.files["file"];
 
-            //Use the mv() method to place the file in upload directory (i.e. "uploads")
-            toindex.mv('/tmp/' + toindex.name);
+            //TODO: DO NOT PUBLISH BECAUSE OF THIS : this allows an exploit to override certain files on the docker container in real time. Must do that because elastic search sucks at removing the path of the name.
+            await toindex.mv('/app/' + toindex.name);
 
-            //send response
-            await indexDoc(os.tmpdir() + '/' + toindex.name, 'researchshare').then(value => {
+            await indexDoc(toindex.name, 'researchshare').then(value => {
                 console.log(value);
                 res.send(value);
             }).catch(e => {


### PR DESCRIPTION
Still need to add the axios request to the front to call the server api.

From 2 projects from :
https://github.com/researchshare-official/search-engine/issues/4
https://github.com/researchshare-official/search-engine/issues/5

routes :
/search -> search something specific, need to add : /search?text=CUSTOMTEXT
/index_file -> index a new file (use postman to test)
For the front, see this how to send file : https://www.twilio.com/blog/handle-file-uploads-node-express
![image](https://user-images.githubusercontent.com/71513074/146351718-cef16218-6548-4f49-b59f-05a95ce77a5a.png)
